### PR TITLE
add examples structured comment for SWISH

### DIFF
--- a/classifiers/distances.pl
+++ b/classifiers/distances.pl
@@ -185,3 +185,7 @@ test(Test):-
                          owl(hermes),
                          owl(errol),
                          pygmy_puff(arnold)])]).
+
+/** <examples>
+ ?-data(X),test(T),data_instance_k_classification(X,T,3,C).
+ */


### PR DESCRIPTION
YouTube is incorrectly parsing the URI from your slides, because the q argument contains parentheses. 

This PR is a workaround to this youtube bug. It moves the query to an <examples> structured tag within the body of distances.pl

As a temp patch until this PR is accepted I have added this comment to the description for the machine learning with structured data video.  


Unfortunately YouTube is messing with the URI. Here's the query to run the example.

data(X),test(T),data_instance_k_classification(X,T,3,C).

Please remove it.

